### PR TITLE
Prevent this page from creating additional dialogues?

### DIFF
--- a/priv/static/scripts/dderl.table.js
+++ b/priv/static/scripts/dderl.table.js
@@ -431,11 +431,29 @@
      * Delete a view
      */
     _deleteView: function() {
-        if(this._viewId && confirm("Are you sure to delete '"+this.options.title+"'")) {
+        if(this._viewId) {
             var self = this;
-            console.log("deleting a view "+this._viewId+" with name "+this.options.title);
-            var delView = {view_op : {operation : "delete", view_id : this._viewId, newname : ""}};
-            self._ajax('view_op', delView, 'view_op', 'opViewResult');
+            var viewName = self.options.title;
+            $('<div><p><span class="ui-icon ui-icon-alert" style="float: left; margin: 0 7px 20px 0;"></span>Are you sure to delete view ' + viewName + '?</p></div>').appendTo(document.body).dialog({
+                resizable: false,
+                height:150,
+                modal: true,
+                buttons: {
+                    "Delete the view": function() {
+                        console.log("deleting a view " + self._viewId + " with name " + viewName);
+                        var delView = {view_op : {operation : "delete", view_id : self._viewId, newname : ""}};
+                        self._ajax('view_op', delView, 'view_op', 'opViewResult');
+                        $( this ).dialog( "close" );
+                    },
+                    Cancel: function() {
+                        $( this ).dialog( "close" );
+                    }
+                },
+                close : function() {
+                    $(this).dialog('destroy');
+                    $(this).remove();
+                }
+            });
         }
     },
 

--- a/priv/static/scripts/dderl.table.js
+++ b/priv/static/scripts/dderl.table.js
@@ -434,26 +434,12 @@
         if(this._viewId) {
             var self = this;
             var viewName = self.options.title;
-            $('<div><p><span class="ui-icon ui-icon-alert" style="float: left; margin: 0 7px 20px 0;"></span>Are you sure to delete view ' + viewName + '?</p></div>').appendTo(document.body).dialog({
-                resizable: false,
-                height:150,
-                modal: true,
-                buttons: {
-                    "Delete the view": function() {
-                        console.log("deleting a view " + self._viewId + " with name " + viewName);
-                        var delView = {view_op : {operation : "delete", view_id : self._viewId, newname : ""}};
-                        self._ajax('view_op', delView, 'view_op', 'opViewResult');
-                        $( this ).dialog( "close" );
-                    },
-                    Cancel: function() {
-                        $( this ).dialog( "close" );
-                    }
-                },
-                close : function() {
-                    $(this).dialog('destroy');
-                    $(this).remove();
-                }
-            });
+            confirm_jq({title: "Confirm delete view " + viewName, content: ''},
+                function() {
+                    console.log("deleting a view " + self._viewId + " with name " + viewName);
+                    var delView = {view_op : {operation : "delete", view_id : self._viewId, newname : ""}};
+                    self._ajax('view_op', delView, 'view_op', 'opViewResult');
+                });
         }
     },
 
@@ -572,17 +558,11 @@
         var columnIds = data.columnIds;
         console.log('show histogram ' + JSON.stringify(data));
 
-        // Considering hidden columns
-        var columnIdsEff = [];
-        for(var i = 0; i < columnIds.length; i++) {
-            columnIdsEff.push(self._origcolumns[self._grid.getColumns()[columnIds[i]].field]);
-        }
-
         $('<div>').appendTo(document.body)
             .statsTable({
                 title          : "Histogram",
                 initialQuery   : self._cmd,
-                columnIds      : columnIdsEff,
+                columnIds      : columnIds,
                 dderlStatement : self._stmt,
                 parent         : self._dlg
             })

--- a/priv/static/scripts/dderl.table.js
+++ b/priv/static/scripts/dderl.table.js
@@ -564,11 +564,17 @@
         var columnIds = data.columnIds;
         console.log('show histogram ' + JSON.stringify(data));
 
+        // Considering hidden columns
+        var columnIdsEff = [];
+        for(var i = 0; i < columnIds.length; i++) {
+            columnIdsEff.push(self._origcolumns[self._grid.getColumns()[columnIds[i]].field]);
+        }
+
         $('<div>').appendTo(document.body)
             .statsTable({
                 title          : "Histogram",
                 initialQuery   : self._cmd,
-                columnIds      : columnIds,
+                columnIds      : columnIdsEff,
                 dderlStatement : self._stmt,
                 parent         : self._dlg
             })


### PR DESCRIPTION
Simple JavaScript commands like alert, confirm and prompt can get lost, if the user activates this browser functionality. The only way around it is to use custom dialogues like JQuery UI's dialogues.

A similar problem exists with renaming prompts or save as prompts etc.   

![image](https://cloud.githubusercontent.com/assets/1956149/13724796/b0075768-e890-11e5-9897-02532fd31d53.png)
