### PR TITLE
Improving the statistics:

### DIFF
--- a/src/gen_adapter.erl
+++ b/src/gen_adapter.erl
@@ -271,7 +271,7 @@ process_cmd({[<<"statistics">>], ReqBody}, _Adapter, _Sess, _UserId, From, _Priv
             ?Error("Stats error ~p", [Error], St),
             jsx:encode([{<<"statistics">>, [{error, Error}]}]);
         {Total, Cols, StatsRows, SN} ->
-            ColRecs = [#stmtCol{alias = C, type = if C =:= <<"column">> -> binstr; true -> float end, readonly = true}
+            ColRecs = [#stmtCol{alias = C, type = case C of <<"column">> -> binstr; <<"count">> -> binstr; _ -> float end, readonly = true}
                       || C <- Cols],
             ?Debug("statistics rows ~p, cols ~p", [StatsRows, ColRecs]),
             StatsJson = gui_resp(#gres{ operation    = <<"rpl">>
@@ -304,7 +304,7 @@ process_cmd({[<<"statistics_full">>], ReqBody}, _Adapter, _Sess, _UserId, From, 
             ?Error("Stats error ~p", [Error], St),
             jsx:encode([{<<"statistics_full">>, [{error, Error}]}]);
         {Total, Cols, StatsRows, SN} ->
-            ColRecs = [#stmtCol{alias = C, type = if C =:= <<"column">> -> binstr; true -> float end, readonly = true}
+            ColRecs = [#stmtCol{alias = C, type = case C of <<"column">> -> binstr; <<"count">> -> binstr; _  -> float end, readonly = true}
                       || C <- Cols],
             StatsJson = gui_resp(#gres{ operation    = <<"rpl">>
                                       , cnt          = Total


### PR DESCRIPTION
Improving the statistics

- new statistical key figures: median and variance
- count: showing total number and number relevant for the statistical key figures
- median: applying the same algorithm as [Oracle](https://docs.oracle.com/cd/E11882_01/server.112/e41084/functions099.htm#SQLRF06315)
- solving some issues with the selected range version (min and max were missing, block selection was not supported, hash for non-numeric values not calculated)
- full column version and selected range version share now pretty much the same code base on the server side

![image](https://cloud.githubusercontent.com/assets/1956149/15420118/1c97a9ea-1e6b-11e6-829d-6332ed0750cf.png)
