### PR TITLE
warning comment on x-frame-options

### DIFF
--- a/src/dderl_cow_mw.erl
+++ b/src/dderl_cow_mw.erl
@@ -5,6 +5,7 @@
 
 execute(Req0, Env) ->
     {Path, Req0} = cowboy_req:path(Req0),
+    %% WARNING: changing x-frame-options from SAMEORIGIN to DENY will break the all file downloads through browsers (IE, Chrome).
     Req1 = cowboy_req:set_resp_header(<<"x-frame-options">>, "SAMEORIGIN", Req0),
     Req2 = cowboy_req:set_resp_header(<<"x-xss-protection">>, "1", Req1),
     Req3 = cowboy_req:set_resp_header(<<"x-content-type-options">>, "nosniff", Req2),


### PR DESCRIPTION
added a warning message (as a comment) to the code to warn developer from changing the code back. Done in reference to https://github.com/K2InformaticsGmbH/sbsgui/issues/1151#issuecomment-265097667.