### PR TITLE
connect tcp treated as an internal connction 

### DIFF
--- a/src/imem_adapter.erl
+++ b/src/imem_adapter.erl
@@ -169,7 +169,7 @@ connect_erlimem_password(Connect, Schema, SessionId, ConnInfo, Params) ->
           Error ->
               error(list_to_binary(io_lib:format("~p", [Error])))
       end,
-    case ErlImemSess:auth(dderl,SessionId,{access,ConnInfo}) of
+    case ErlImemSess:auth(dderl,SessionId,{access,ConnInfo#{type => internal}}) of
         {ok, [{pwdmd5,_}|_]} ->
             User = proplists:get_value(<<"user">>, Params, <<>>),
             Password = proplists:get_value(<<"password">>, Params, []),


### PR DESCRIPTION
Fixes #444
if multiple authentication methods are being used then edit the `[{imem,imem_seco,authenticateRequireFun}]` and add the following
```erlang
<<"
fun (Factors, NetCtx) ->
	case NetCtx of
	  #{type := internal} -> [pwdmd5];
	  #{tcp := #{peerip := {1, 2, 3, 4}}} ->
	      [saml, pwdmd5, smsott];
	  _ -> [pwdmd5]
	end
	  -- Factors
end
">>
```