### PR TITLE
dynamic erloci dependency

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -1,0 +1,8 @@
+case os:getenv("NO_OCI") of
+    "true" ->
+        ConfigMap = maps:from_list(CONFIG),
+        #{deps := Deps} = ConfigMap,
+        DepsWithoutOci = lists:keydelete(erloci, 1, Deps),
+        maps:to_list(ConfigMap#{deps => DepsWithoutOci});
+    _ -> CONFIG % env var set to empty string
+end.

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -1,8 +1,9 @@
 case os:getenv("NO_OCI") of
     "true" ->
+        %% removing erloci dependency
         ConfigMap = maps:from_list(CONFIG),
         #{deps := Deps} = ConfigMap,
         DepsWithoutOci = lists:keydelete(erloci, 1, Deps),
         maps:to_list(ConfigMap#{deps => DepsWithoutOci});
-    _ -> CONFIG % env var set to empty string
+    _ -> CONFIG
 end.

--- a/src/dderl.app.src.script
+++ b/src/dderl.app.src.script
@@ -1,7 +1,8 @@
 case os:getenv("NO_OCI") of
     "true" ->
+        %% removing erloci from list of dependent applications
         [{application, dderl, Conf}] = CONFIG,
         #{applications := Apps} = ConfMap = maps:from_list(Conf),
         [{application, dderl, maps:to_list(ConfMap#{applications => lists:delete(erloci, Apps)})}];
-    _ -> CONFIG % env var set to empty string
+    _ -> CONFIG
 end.

--- a/src/dderl.app.src.script
+++ b/src/dderl.app.src.script
@@ -1,0 +1,7 @@
+case os:getenv("NO_OCI") of
+    "true" ->
+        [{application, dderl, Conf}] = CONFIG,
+        #{applications := Apps} = ConfMap = maps:from_list(Conf),
+        [{application, dderl, maps:to_list(ConfMap#{applications => lists:delete(erloci, Apps)})}];
+    _ -> CONFIG % env var set to empty string
+end.


### PR DESCRIPTION
to remove erloci use `NO_OCI=true` in front of the rebar3 commands.
for example
```
NO_OCI=true rebar3 compile
```
erloci will not be started if not included.