### PR TITLE
Fixed bad HTTP response header content-encoding value

### DIFF
--- a/src/dderl_resource.erl
+++ b/src/dderl_resource.erl
@@ -187,8 +187,7 @@ reply_200_json(Body, SessionToken, Req) ->
             cowboy_req:set_resp_cookie(CookieName, SessToken, Req, Opts)
     end,
     cowboy_req:reply(200, 
-          #{<<"content-encoding">> => <<"utf-8">>,
-            <<"content-type">> => <<"application/json">>}
+          #{<<"content-type">> => <<"application/json; charset=utf-8">>}
         , Body, ?COW_REQ_SET_META(respSize, byte_size(Body), Req1)).
 
 reply_csv(FileName, Chunk, ChunkIdx, Req) ->

--- a/src/dderl_rest.hrl
+++ b/src/dderl_rest.hrl
@@ -6,8 +6,7 @@
           <<"cache-control">> => <<"no-cache, no-store, must-revalidate">>,
           <<"server">> => <<?SERVER>>}).
 -define(REPLY_JSON_HEADERS,
-        maps:merge(#{<<"content-encoding">> => <<"utf-8">>,
-                     <<"content-type">> => <<"application/json">>},
+        maps:merge(#{<<"content-type">> => <<"application/json; charset=utf-8">>},
                    ?REPLY_HEADERS)).
 -define(REPLY_JSON_SPEC_HEADERS,
         maps:merge(#{<<"connection">> => <<"close">>,


### PR DESCRIPTION
fixes #528

Fixed content-encoding being incorrectly set to utf-8, by adding it as charset=utf-8 to the content-type. 