### PR TITLE
remote_apps - using application:which_applications()

### DIFF
--- a/src/oci_adapter.erl
+++ b/src/oci_adapter.erl
@@ -208,6 +208,7 @@ process_cmd({[<<"remote_apps">>], ReqBody}, _Sess, _UserId, From, #priv{connecti
     Connection = ?D2T(proplists:get_value(<<"connection">>, BodyJson, <<>>)),
     case lists:member(Connection, Connections) of
         true ->
+            % erloci instance is always in local node
             Apps = application:which_applications(),
             Versions = dderl_session:get_apps_version(Apps, []),
             From ! {reply, jsx:encode([{<<"remote_apps">>, Versions}])},

--- a/src/oci_adapter.erl
+++ b/src/oci_adapter.erl
@@ -208,7 +208,7 @@ process_cmd({[<<"remote_apps">>], ReqBody}, _Sess, _UserId, From, #priv{connecti
     Connection = ?D2T(proplists:get_value(<<"connection">>, BodyJson, <<>>)),
     case lists:member(Connection, Connections) of
         true ->
-            Apps = Connection:run_cmd(which_applications, []),
+            Apps = application:which_applications(),
             Versions = dderl_session:get_apps_version(Apps, []),
             From ! {reply, jsx:encode([{<<"remote_apps">>, Versions}])},
             Priv;


### PR DESCRIPTION
fixes #531 
erloci will always be running local to dderl server