### PR TITLE
swagger update to 3.18 from K2 fork

### DIFF
--- a/priv/swagger/package.json
+++ b/priv/swagger/package.json
@@ -15,7 +15,7 @@
     "file-loader": "^1.1.11",
     "jquery": "^3.3.1",
     "popper.js": "^1.14.3",
-    "swagger-ui": "https://github.com/K2InformaticsGmbH/swagger-ui/archive/v3.18.0.tar.gz"
+    "swagger-ui": "^3.18.0"
   },
   "devDependencies": {
     "clean-webpack-plugin": "^0.1.19",

--- a/priv/swagger/package.json
+++ b/priv/swagger/package.json
@@ -15,7 +15,7 @@
     "file-loader": "^1.1.11",
     "jquery": "^3.3.1",
     "popper.js": "^1.14.3",
-    "swagger-ui": "^3.14.0"
+    "swagger-ui": "https://github.com/K2InformaticsGmbH/swagger-ui/archive/v3.18.0.tar.gz"
   },
   "devDependencies": {
     "clean-webpack-plugin": "^0.1.19",


### PR DESCRIPTION
fixes https://github.com/K2InformaticsGmbH/dderl/issues/539

Deps pull of swagger-ui-3.18 from K2 fork works.
@shamis : Can you please verify if the bug is fixed with PR and then merge it?