### PR TITLE
yarn instead of npm install

### DIFF
--- a/priv/dev/package.json
+++ b/priv/dev/package.json
@@ -38,7 +38,7 @@
     "webpack": "3.10.0"
   },
   "scripts": {
-    "install-build-prod": "npm install && npm run build-prod",
+    "install-build-prod": "yarn && npm run build-prod",
     "build-dev": "npm run lint && npm run clean && webpack --progress",
     "build-prod": "npm run lint && npm run clean && webpack -p",
     "clean": "rimraf ../public/dist",


### PR DESCRIPTION
`npm install` may run into https://github.com/npm/npm/issues/20925 when through proxy