### PR TITLE
Add macro with rest spec file as argument for reply_json_spec_headers.

### DIFF
--- a/src/dderl_rest.hrl
+++ b/src/dderl_rest.hrl
@@ -8,12 +8,15 @@
 -define(REPLY_JSON_HEADERS,
         maps:merge(#{<<"content-type">> => <<"application/json; charset=utf-8">>},
                    ?REPLY_HEADERS)).
--define(REPLY_JSON_SPEC_HEADERS,
-        maps:merge(#{<<"connection">> => <<"close">>,
-         <<"content-type">> => <<"application/json; charset=UTF-8">>,
-         <<"content-disposition">> => <<"attachment; filename=\"",?SPEC_FILE,"\"">>},
-         ?REPLY_HEADERS)).
+-define(REPLY_JSON_SPEC_HEADERS, ?REPLY_JSON_SPEC_HEADERS(?SPEC_FILE)).
+       
 -define(REPLY_OPT_HEADERS,
         maps:merge(#{<<"connection">> => <<"close">>}, ?REPLY_HEADERS)).
+
+-define(REPLY_JSON_SPEC_HEADERS(__SPEC_FILE__), 
+        maps:merge(#{<<"connection">> => <<"close">>,
+                <<"content-type">> => <<"application/json; charset=UTF-8">>,
+                <<"content-disposition">> => list_to_binary(["attachment; filename=\"",__SPEC_FILE__,"\""])},
+         ?REPLY_HEADERS)).
 
 -endif. % DDERL_REST_HRL

--- a/src/dderl_rest.hrl
+++ b/src/dderl_rest.hrl
@@ -5,11 +5,13 @@
         #{<<"access-control-allow-origin">> => <<"*">>,
           <<"cache-control">> => <<"no-cache, no-store, must-revalidate">>,
           <<"server">> => <<?SERVER>>}).
+
 -define(REPLY_JSON_HEADERS,
         maps:merge(#{<<"content-type">> => <<"application/json; charset=utf-8">>},
                    ?REPLY_HEADERS)).
+
 -define(REPLY_JSON_SPEC_HEADERS, ?REPLY_JSON_SPEC_HEADERS(?SPEC_FILE)).
-       
+
 -define(REPLY_OPT_HEADERS,
         maps:merge(#{<<"connection">> => <<"close">>}, ?REPLY_HEADERS)).
 


### PR DESCRIPTION
Needed for versioning rest with backwards compatibility.