### PR TITLE
009131 csv download badmatch error

### DIFF
--- a/src/dderl_session.erl
+++ b/src/dderl_session.erl
@@ -532,7 +532,7 @@ process_call({[<<"download_buffer_csv">>], ReqData}, Adapter, From, {SrcIp, _},
     Statement = binary_to_term(base64:decode(proplists:get_value(<<"statement">>, BodyJson, <<>>))),
     ColumnPositions = proplists:get_value(<<"column_positions">>, BodyJson, []),
     Filename = proplists:get_value(<<"filename">>, BodyJson, <<>>),
-    {TableId, IndexId, Nav, RowFun, OrigClms} = Statement:get_sender_params(),
+    {TableId, IndexId, Nav, RowFun, OrigClms, _FilterSpec} = Statement:get_sender_params(),
     UsedTable = case Nav of
         raw -> TableId;
         ind -> IndexId


### PR DESCRIPTION
this issue was introduced in https://github.com/K2InformaticsGmbH/dderl/pull/634
When `dderl_fsm:get_sender_params/1` was changed to add `FilterSpec`, it was not updated in `dderl_session`